### PR TITLE
allow `html_short_title`

### DIFF
--- a/docs/src/configuration.rst
+++ b/docs/src/configuration.rst
@@ -1,0 +1,19 @@
+Configuration
+=============
+
+html_short_title
+----------------
+
+If you have a really long project name, you may prefer something shorter to
+appear in the navigation bar. Specify this using ``html_short_title`` in
+``conf.py``:
+
+.. code-block:: python
+
+    # conf.py
+
+    # By default the project value is used in the nav bar.
+    project = 'My Extra Special Amazing Docs'
+
+    # If specified, this will be used in the nav bar instead.
+    html_short_title = "Amazing Docs"

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -8,6 +8,7 @@ A clean and modern theme for `Sphinx <https://www.sphinx-doc.org/en/master/>`_.
    :caption: Contents:
 
    ./setup.rst
+   ./configuration.rst
    ./help.rst
    ./support_us.rst
    ./about.rst

--- a/piccolo_theme/layout.html
+++ b/piccolo_theme/layout.html
@@ -6,7 +6,7 @@
     <p id="toggle_sidebar">
         <a href="#" title="Toggle sidebar">|||</a>
     </p>
-    <h1><a href="{{ pathto(root_doc)|e }}" title="Go to homepage">{{ project }}</a></h1>
+    <h1><a href="{{ pathto(root_doc)|e }}" title="Go to homepage">{{ shorttitle or project }}</a></h1>
 
     {% include "./components/dark_mode_toggle.html" %}
 


### PR DESCRIPTION
If `html_short_title` is in `conf.py` then this is used in the nav bar instead of the full project title.
