### PR TITLE
add support for Python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Related to https://github.com/piccolo-orm/piccolo_theme/issues/32

Many systems will still be on Python 3.6, and Sphinx still supports it:

https://github.com/sphinx-doc/sphinx/blob/8c7a472d58f832b9e2bd05d9d0fd5dbe0fcf077f/setup.py

So adding backwards compatibility.