### PR TITLE
change colour used for emphasis in code blocks

### DIFF
--- a/docs/src/demo.rst
+++ b/docs/src/demo.rst
@@ -47,6 +47,24 @@ Emphasize
   def say_hello():
       print("hello world!")
 
+Line numbers
+~~~~~~~~~~~~
+
+.. code-block:: python
+  :linenos:
+
+  def say_hello():
+      print("hello world!")
+
+Caption
+~~~~~~~
+
+.. code-block:: python
+  :caption: Some example code
+
+  def say_hello():
+      print("hello world!")
+
 -------------------------------------------------------------------------------
 
 Tables

--- a/docs/src/demo.rst
+++ b/docs/src/demo.rst
@@ -27,6 +27,28 @@ Breathe
 
 -------------------------------------------------------------------------------
 
+Code Blocks
+-----------
+
+Basic
+~~~~~
+
+.. code-block:: python
+
+  def say_hello():
+      print("hello world!")
+
+Emphasize
+~~~~~~~~~
+
+.. code-block:: python
+  :emphasize-lines: 1,2
+
+  def say_hello():
+      print("hello world!")
+
+-------------------------------------------------------------------------------
+
 Tables
 ------
 

--- a/piccolo_theme/static/basic_mod.css
+++ b/piccolo_theme/static/basic_mod.css
@@ -735,7 +735,7 @@ div.button_nav_wrapper div.button_nav div.right a span.icon {
   --torquoise: #68e9e9;
   --brown: #d48a00;
   --purple: #ce04e9;
-  --paleYellow: #ffffc0;
+  --paleYellow: #454534;
   background: var(--codeBackgroundColor);
   color: var(--fontColor);
   /* Comment */

--- a/src/sass/basic_mod.scss
+++ b/src/sass/basic_mod.scss
@@ -923,7 +923,7 @@ div.button_nav_wrapper {
     --torquoise: #68e9e9;
     --brown: #d48a00;
     --purple: #ce04e9;
-    --paleYellow: #ffffc0;
+    --paleYellow: #454534;
 
     background: var(--codeBackgroundColor);
     color: var(--fontColor);


### PR DESCRIPTION
Resolves https://github.com/piccolo-orm/piccolo_theme/issues/48

Before:

<img width="322" alt="Screenshot 2023-03-15 at 21 20 03" src="https://user-images.githubusercontent.com/350976/225446458-bfdfa129-402c-4b18-a707-056ef53f4cb1.png">

After:

<img width="461" alt="Screenshot 2023-03-15 at 21 16 43" src="https://user-images.githubusercontent.com/350976/225446253-8fadef18-fcdf-4c3d-a1d7-1cc2576158ab.png">
