### PR TITLE
fix span html closing tag

### DIFF
--- a/piccolo_theme/layout.html
+++ b/piccolo_theme/layout.html
@@ -54,11 +54,11 @@
 {%- block sidebar2 %}
     {% if display_toc %}
         <div id="show_right_sidebar">
-            <p><a class="toggle_right_sidebar" href="#"><span class="icon">&lt;</span><span>Page contents<span></a></p>
+            <p><a class="toggle_right_sidebar" href="#"><span class="icon">&lt;</span><span>Page contents</span></a></p>
         </div>
 
         <div id="right_sidebar">
-            <p><a class="toggle_right_sidebar" href="#"><span class="icon">&gt;</span><span>Page contents:<span></a></p>
+            <p><a class="toggle_right_sidebar" href="#"><span class="icon">&gt;</span><span>Page contents:</span></a></p>
             <div class="page_toc">
                 {{ toc }}
             </div>


### PR DESCRIPTION
Hi, I ran [prettier](https://prettier.io/) formatter over the html output produced by `piccolo_theme` and noticed an error in some span tags. It's a really small change so it should be ready to go.

Thank you for the theme!